### PR TITLE
added wgs84/projected_coordinate_system vars with attrs to network file

### DIFF
--- a/dfm_tools/download.py
+++ b/dfm_tools/download.py
@@ -47,7 +47,7 @@ def download_ERA5(varkey,
                       'v10n':'10m_v_component_of_neutral_wind',
                       'mer':'mean_evaporation_rate',
                       'mtpr':'mean_total_precipitation_rate',
-                      'p140209':'air_density_over_the_ocean',
+                      'p140209':'air_density_over_the_oceans',
                       }
     if varkey not in variables_dict.keys(): #TODO: how to get list of available vars? mean_sea_level_pressure and msl both return a dataset with msl varkey, but standard_name air_pressure_at_mean_sea_level returns an error
         raise KeyError(f'"{varkey}" not available, choose from: {list(variables_dict.keys())}')

--- a/dfm_tools/meshkernel_helpers.py
+++ b/dfm_tools/meshkernel_helpers.py
@@ -115,10 +115,10 @@ def meshkernel_to_UgridDataset(mk:meshkernel.MeshKernel, remove_noncontiguous:bo
             'name': 'WGS84',
             'epsg': np.array(4326, dtype=int),
             'grid_mapping_name': 'latitude_longitude',
-            'longitude_of_prime_meridian': np.array(0.0, dtype=float),
-            'semi_major_axis': np.array(6378137.0, dtype=float),
-            'semi_minor_axis': np.array(6356752.314245, dtype=float),
-            'inverse_flattening': np.array(298.257223563, dtype=float),
+            'longitude_of_prime_meridian': np.array(0.0, dtype=float),#TODO: also without this interacter recognizes the grid as spherical
+            'semi_major_axis': np.array(6378137.0, dtype=float),#TODO: also without this interacter recognizes the grid as spherical
+            'semi_minor_axis': np.array(6356752.314245, dtype=float),#TODO: also without this interacter recognizes the grid as spherical
+            'inverse_flattening': np.array(298.257223563, dtype=float),#TODO: also without this interacter recognizes the grid as spherical
             'EPSG_code': 'EPSG:4326',
             }
         crs_varn = 'wgs84'

--- a/dfm_tools/meshkernel_helpers.py
+++ b/dfm_tools/meshkernel_helpers.py
@@ -112,25 +112,25 @@ def meshkernel_to_UgridDataset(mk:meshkernel.MeshKernel, remove_noncontiguous:bo
     # add wgs84/projected_coordinate_system variable with attrs
     if is_geographic: #TODO: extend this with flexible crs
         attribute_dict = {
-            'name': 'WGS84',
-            'epsg': np.array(4326, dtype=int),
-            'grid_mapping_name': 'latitude_longitude',
-            'longitude_of_prime_meridian': np.array(0.0, dtype=float),#TODO: also without this interacter recognizes the grid as spherical
-            'semi_major_axis': np.array(6378137.0, dtype=float),#TODO: also without this interacter recognizes the grid as spherical
-            'semi_minor_axis': np.array(6356752.314245, dtype=float),#TODO: also without this interacter recognizes the grid as spherical
-            'inverse_flattening': np.array(298.257223563, dtype=float),#TODO: also without this interacter recognizes the grid as spherical
-            'EPSG_code': 'EPSG:4326',
+            #'name': 'WGS84',#TODO: also without this interacter recognizes the grid as spherical
+            #'epsg': np.array(4326, dtype=int), #epsg or EPSG_code should be present for the interacter to load the grid
+            'grid_mapping_name': 'latitude_longitude', #without this, interacter sees the grid as cartesian
+            # 'longitude_of_prime_meridian': np.array(0.0, dtype=float),#TODO: also without this interacter recognizes the grid as spherical
+            # 'semi_major_axis': np.array(6378137.0, dtype=float),#TODO: also without this interacter recognizes the grid as spherical
+            # 'semi_minor_axis': np.array(6356752.314245, dtype=float),#TODO: also without this interacter recognizes the grid as spherical
+            # 'inverse_flattening': np.array(298.257223563, dtype=float),#TODO: also without this interacter recognizes the grid as spherical
+            'EPSG_code': 'EPSG:4326', #epsg or EPSG_code should be present for the interacter to load the grid. EPSG_code is required from QGIS
             }
         crs_varn = 'wgs84'
     else:
         attribute_dict = {
-            'name': 'Unknown projected',
-            'epsg': np.array(28992, dtype=int),
+            #'name': 'Unknown projected',
+            #'epsg': np.array(28992, dtype=int),
             'grid_mapping_name': 'Unknown projected',
-            'longitude_of_prime_meridian': np.array(0.0, dtype=float),
-            'semi_major_axis': np.array(6377397.155, dtype=float),
-            'semi_minor_axis': np.array(6356078.962818189, dtype=float),
-            'inverse_flattening': np.array(299.1528128, dtype=float),
+            #'longitude_of_prime_meridian': np.array(0.0, dtype=float),
+            #'semi_major_axis': np.array(6377397.155, dtype=float),
+            #'semi_minor_axis': np.array(6356078.962818189, dtype=float),
+            #'inverse_flattening': np.array(299.1528128, dtype=float),
             'EPSG_code': 'EPSG:28992',
             #'wkt': 'PROJCS["Amersfoort / RD New",\n    GEOGCS["...'
             }

--- a/dfm_tools/meshkernel_helpers.py
+++ b/dfm_tools/meshkernel_helpers.py
@@ -112,13 +112,13 @@ def meshkernel_to_UgridDataset(mk:meshkernel.MeshKernel, remove_noncontiguous:bo
     # add wgs84/projected_coordinate_system variable with attrs
     if is_geographic: #TODO: extend this with flexible crs
         attribute_dict = {
-            'name': 'Unknown projected',
+            'name': 'WGS84',
             'epsg': np.array(4326, dtype=int),
-            'grid_mapping_name': 'Unknown projected',
+            'grid_mapping_name': 'latitude_longitude',
             'longitude_of_prime_meridian': np.array(0.0, dtype=float),
             'semi_major_axis': np.array(6378137.0, dtype=float),
             'semi_minor_axis': np.array(6356752.314245, dtype=float),
-            'inverse_flattening': np.array(6356752.314245, dtype=float),
+            'inverse_flattening': np.array(298.257223563, dtype=float),
             'EPSG_code': 'EPSG:4326',
             }
         crs_varn = 'wgs84'

--- a/dfm_tools/meshkernel_helpers.py
+++ b/dfm_tools/meshkernel_helpers.py
@@ -118,12 +118,13 @@ def meshkernel_to_UgridDataset(mk:meshkernel.MeshKernel, crs=None, remove_noncon
         xu_grid_ds[varn_conn].attrs["_FillValue"] += 1
         xu_grid_ds[varn_conn].attrs["start_index"] += 1
     
-    xu_grid_ds = xu_grid_ds.assign_attrs({#'Conventions': 'CF-1.8 UGRID-1.0 Deltares-0.10', #TODO: add Deltares convention (was CF-1.8 UGRID-1.0)
+    xu_grid_ds = xu_grid_ds.assign_attrs({#'Conventions': 'CF-1.8 UGRID-1.0 Deltares-0.10', #TODO: conventions come from xugrid, so this line is not necessary
                                           'institution': 'Deltares',
                                           'references': 'https://www.deltares.nl',
                                           'source': f'Created with meshkernel {meshkernel.__version__}, xugrid {xu.__version__} and dfm_tools {__version__}',
                                           'history': 'Created on %s, %s'%(dt.datetime.now().strftime('%Y-%m-%dT%H:%M:%S%z'),getpass.getuser()), #TODO: add timezone
                                           })
+    #TODO: xugrid overwrites this upon saving the network file: https://github.com/Deltares/xugrid/issues/111
     
     xu_grid_uds = xu.UgridDataset(xu_grid_ds)
     add_crs_to_dataset(uds=xu_grid_uds,is_geographic=is_geographic,crs=crs)

--- a/dfm_tools/meshkernel_helpers.py
+++ b/dfm_tools/meshkernel_helpers.py
@@ -48,7 +48,7 @@ def meshkernel_delete_withpol(mk, file_ldb, minpoints=None):
     """
     empty docstring
     """
-    #TODO: read file_ldb as geodataframe (convert pointlike to geodataframe) and merge code with meshkernel_delete_withcoastlines
+    #TODO: read file_ldb as geodataframe (convert pointlike to geodataframe) and merge code with meshkernel_delete_withcoastlines: https://github.com/Deltares/dfm_tools/issues/427
     
     print('>> reading+converting ldb: ',end='')
     dtstart = dt.datetime.now()

--- a/dfm_tools/meshkernel_helpers.py
+++ b/dfm_tools/meshkernel_helpers.py
@@ -120,7 +120,7 @@ def meshkernel_to_UgridDataset(mk:meshkernel.MeshKernel, remove_noncontiguous:bo
             'semi_minor_axis': np.array(6356752.314245, dtype=float),
             'inverse_flattening': np.array(6356752.314245, dtype=float),
             'EPSG_code': 'EPSG:4326',
-            'value': 'value is equal to EPSG code'}
+            }
         crs_varn = 'wgs84'
     else:
         attribute_dict = {

--- a/dfm_tools/meshkernel_helpers.py
+++ b/dfm_tools/meshkernel_helpers.py
@@ -73,7 +73,8 @@ def meshkernel_to_UgridDataset(mk:meshkernel.MeshKernel, remove_noncontiguous:bo
     empty docstring
     """
     mesh2d_grid3 = mk.mesh2d_get()
-
+    #TODO: get is_geographic from mk and drop as input argument: https:/https://github.com/Deltares/MeshKernelPy/issues/69/github.com/Deltares/MeshKernelPy/issues/69
+    
     xu_grid = xu.Ugrid2d.from_meshkernel(mesh2d_grid3)
     
     #remove non-contiguous grid parts

--- a/dfm_tools/meshkernel_helpers.py
+++ b/dfm_tools/meshkernel_helpers.py
@@ -72,11 +72,10 @@ def meshkernel_check_geographic(mk):
     """
     get projection from meshkernel instance
     """
-    is_geographic = bool(mk.get_projection().value) #TODO: better would be doing the below, but ProjectionType is not yet exposed: https://github.com/Deltares/MeshKernelPy/pull/77
-    # if mk.get_projection()==meshkernel.ProjectionType.Spherical:
-    #     is_geographic = True
-    # else:
-    #     is_geographic = False
+    if mk.get_projection()==meshkernel.ProjectionType.SPHERICAL:
+        is_geographic = True
+    else:
+        is_geographic = False
     return is_geographic
 
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -13,7 +13,8 @@
 - proper selection for either CMEMS reanalysis/forecast product in `download_CMEMS()` by [@JulienGroenenboom](https://github.com/JulienGroenenboom) in [#308](https://github.com/Deltares/dfm_tools/pull/388)
 - slightly extend spatial and time domain when downloading ERA5 and CMEMS data by [@JulienGroenenboom](https://github.com/JulienGroenenboom) in [#390](https://github.com/Deltares/dfm_tools/pull/390)
 - renamed uxuy to uxuyadvectionvelocitybnd in `open_dataset_extra()` and related example script by [@veenstrajelmer](https://github.com/veenstrajelmer) in [#366](https://github.com/Deltares/dfm_tools/pull/366)
-- add warning when interpolating to a boundary that contains multiple polylines by [@Tammo-Zijlker-Deltares](https://github.com/Tammo-Zijlker-Deltares)[#372](https://github.com/Deltares/dfm_tools/pull/372)
+- add warning when interpolating to a boundary that contains multiple polylines by [@Tammo-Zijlker-Deltares](https://github.com/Tammo-Zijlker-Deltares) in [#372](https://github.com/Deltares/dfm_tools/pull/372)
+- improved netcdf writing from meshkernel+xugrid generated network with `add_crs_to_dataset()` by [@veenstrajelmer](https://github.com/veenstrajelmer) in [#422](https://github.com/Deltares/dfm_tools/pull/422)
 
 ## 0.11.0 (2023-04-24)
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -32,7 +32,7 @@ Replaced large parts of the code with [HYDROLIB-core](https://github.com/Deltare
 - renaming water quality variables in dataset with `rename_waqvars()` by [@veenstrajelmer](https://github.com/veenstrajelmer) in [#259](https://github.com/Deltares/dfm_tools/pull/259), this deprecates `get_varnamefromattrs()`
 - renaming variables in fourier dataset with `rename_fouvars()` by [@veenstrajelmer](https://github.com/veenstrajelmer) in [#283](https://github.com/Deltares/dfm_tools/pull/283)
 - simplified background plotting with contextily and cartopy by [@veenstrajelmer](https://github.com/veenstrajelmer) in [#328](https://github.com/Deltares/dfm_tools/pull/328), this deprecates `plot_background()`
-- create release and pypipip installable by [@veenstrajelmer](https://github.com/veenstrajelmer) in [#338](https://github.com/Deltares/dfm_tools/pull/338)
+- create release and pypi/pip installable by [@veenstrajelmer](https://github.com/veenstrajelmer) in [#338](https://github.com/Deltares/dfm_tools/pull/338)
 - using [HYDROLIB-core](https://github.com/Deltares/hydrolib-core) for reading/writing of D-FlowFM files, this deprecates `write_bcfile()`, `read_bcfile()`, `Polygon()`, `write_timfile()` and `read_timfile()`
 - interpolation of regularly gridded dataset (CMEMS, HYCOM etc) to plipoints with `interp_regularnc_to_plipoints()` by [@veenstrajelmer](https://github.com/veenstrajelmer)
 - interpolation of regularly gridded tide datasets to plipoints with `interpolate_tide_to_bc()` by [@veenstrajelmer](https://github.com/veenstrajelmer) in [#288](https://github.com/Deltares/dfm_tools/pull/288)

--- a/tests/examples_workinprogress/workinprogress_meshkernel_creategrid.py
+++ b/tests/examples_workinprogress/workinprogress_meshkernel_creategrid.py
@@ -93,8 +93,8 @@ mesh_refinement_parameters = meshkernel.MeshRefinementParameters(#refine_interse
                                                                  max_courant_time=150) #TODO: consider 200 (gtsm value), is this value read?
 
 mk.mesh2d_refine_based_on_gridded_samples(gridded_samples=gridded_samples,
-                                           mesh_refinement_params=mesh_refinement_parameters,
-                                           use_nodal_refinement=True) #TODO: what does this do?
+                                          mesh_refinement_params=mesh_refinement_parameters,
+                                          use_nodal_refinement=True) #TODO: what does this do?
 
 mesh2d_refinedgrid = mk.mesh2d_get()
 fig, ax = plt.subplots(figsize=figsize)

--- a/tests/examples_workinprogress/workinprogress_meshkernel_creategrid.py
+++ b/tests/examples_workinprogress/workinprogress_meshkernel_creategrid.py
@@ -23,7 +23,7 @@ lon_res,lat_res = 0.2,0.2
 is_geographic = True #True for spherical grids
 
 figsize = (10,4)
-crs = 'EPSG:4326' #TODO: couple to is_geographic
+crs = 'EPSG:4326'
 
 
 """
@@ -37,7 +37,7 @@ Make a regular (potentially rotated) rectilinear grid. First generate a curvilin
 make_grid_parameters = meshkernel.MakeGridParameters(angle=0.0, #TODO: does non-zero result in an orthogonal spherical grid?
                                                      origin_x=lon_min,
                                                      origin_y=lat_min,
-                                                     upper_right_x=lon_max, #TODO: angle and upper_right_x cannot be combined
+                                                     upper_right_x=lon_max, #TODO: angle and upper_right_x cannot be combined: https://github.com/Deltares/MeshKernelPy/issues/74
                                                      upper_right_y=lat_max,
                                                      block_size_x=lon_res,
                                                      block_size_y=lat_res)
@@ -53,7 +53,7 @@ else:
 
 
 mk = meshkernel.MeshKernel(is_geographic=is_geographic)
-mk.curvilinear_make_uniform_on_extension(make_grid_parameters) #TODO: geometry_list is possible with curvilinear_make_uniform, but not for this function
+mk.curvilinear_make_uniform_on_extension(make_grid_parameters) #TODO: geometry_list is possible with curvilinear_make_uniform, but not for this function: https://github.com/Deltares/MeshKernelPy/issues/76
 mk.curvilinear_convert_to_mesh2d() #convert to ugrid/mesh2d
 mesh2d_basegrid = mk.mesh2d_get() #in case of curvi grid: mk.curvilinear_convert_to_mesh2d()
 fig, ax = plt.subplots(figsize=figsize)
@@ -132,7 +132,7 @@ ctx.add_basemap(ax=ax, crs=crs, attribution=False)
 convert meshkernel grid to xugrid, interp bathymetry, plot and save to *_net.nc
 """
 
-xu_grid_uds = dfmt.meshkernel_to_UgridDataset(mk, remove_noncontiguous=True, is_geographic=is_geographic) #TODO: put remove_noncontiguous in meshkernel?: https://github.com/Deltares/MeshKernelPy/issues/44
+xu_grid_uds = dfmt.meshkernel_to_UgridDataset(mk, remove_noncontiguous=True, is_geographic=is_geographic, crs=crs) #TODO: put remove_noncontiguous in meshkernel?: https://github.com/Deltares/MeshKernelPy/issues/44
 
 fig, ax = plt.subplots(figsize=figsize)
 xu_grid_uds.grid.plot(ax=ax) #TODO: maybe make uds instead of ds (but then bathy interpolation goes wrong)
@@ -152,6 +152,5 @@ xu_grid_uds.ugrid.to_netcdf('test_net.nc')
 
 #TODO: update https://github.com/Deltares/dfm_tools/issues/217
 
-#TODO: network file is not orthogonal, should be fixed with https://github.com/Deltares/dfm_tools/issues/421
 #TODO: there is (was) a link missing, maybe due to ldb?
 

--- a/tests/examples_workinprogress/workinprogress_meshkernel_creategrid.py
+++ b/tests/examples_workinprogress/workinprogress_meshkernel_creategrid.py
@@ -134,8 +134,7 @@ ctx.add_basemap(ax=ax, crs=crs, attribution=False)
 convert meshkernel grid to xugrid, interp bathymetry, plot and save to *_net.nc
 """
 
-xu_grid_uds = dfmt.meshkernel_to_UgridDataset(mk, remove_noncontiguous=True, is_geographic=is_geographic, crs=crs) #TODO: put remove_noncontiguous in meshkernel?: https://github.com/Deltares/MeshKernelPy/issues/44
-#TODO: get is_geographic from mk and drop as input argument: https:/https://github.com/Deltares/MeshKernelPy/issues/69/github.com/Deltares/MeshKernelPy/issues/69
+xu_grid_uds = dfmt.meshkernel_to_UgridDataset(mk, remove_noncontiguous=True, crs=crs) #TODO: put remove_noncontiguous in meshkernel?: https://github.com/Deltares/MeshKernelPy/issues/44
 
 fig, ax = plt.subplots(figsize=figsize)
 xu_grid_uds.grid.plot(ax=ax,linewidth=0.8) #TODO: maybe make uds instead of ds (but then bathy interpolation goes wrong)

--- a/tests/examples_workinprogress/workinprogress_meshkernel_creategrid.py
+++ b/tests/examples_workinprogress/workinprogress_meshkernel_creategrid.py
@@ -132,8 +132,7 @@ ctx.add_basemap(ax=ax, crs=crs, attribution=False)
 convert meshkernel grid to xugrid, interp bathymetry, plot and save to *_net.nc
 """
 
-xu_grid_uds = dfmt.meshkernel_to_UgridDataset(mk, remove_noncontiguous=True) #TODO: put remove_noncontiguous in meshkernel?: https://github.com/Deltares/MeshKernelPy/issues/44
-#TODO: add wgs84 variable with attrs: https://github.com/Deltares/dfm_tools/issues/421
+xu_grid_uds = dfmt.meshkernel_to_UgridDataset(mk, remove_noncontiguous=True, is_geographic=is_geographic) #TODO: put remove_noncontiguous in meshkernel?: https://github.com/Deltares/MeshKernelPy/issues/44
 
 fig, ax = plt.subplots(figsize=figsize)
 xu_grid_uds.grid.plot(ax=ax) #TODO: maybe make uds instead of ds (but then bathy interpolation goes wrong)

--- a/tests/examples_workinprogress/workinprogress_meshkernel_creategrid.py
+++ b/tests/examples_workinprogress/workinprogress_meshkernel_creategrid.py
@@ -112,7 +112,9 @@ delete (landward) part of grid with polygon and plot result
 #                         [ 0.20387097, 49.9       ],
 #                         [-0.25032258, 48.71290323],
 #                         [ 1.92774194, 48.59935484]])
-dfmt.meshkernel_delete_withcoastlines(mk=mk, res='h', min_area=1000)
+print('deleting coastlines (takes a while)...')
+dfmt.meshkernel_delete_withcoastlines(mk=mk, res='h', min_area=100)
+print('done')
 
 
 mesh2d_noland = mk.mesh2d_get()
@@ -123,7 +125,7 @@ mesh2d_noland.plot_edges(ax,linewidth=0.8)
 #     ax.plot(pol_del['x'],pol_del['y'],'-r')
 # ax.set_xlim(xlim)
 # ax.set_ylim(ylim)
-dfmt.plot_coastlines(ax=ax, res='h', min_area=1000)
+dfmt.plot_coastlines(ax=ax, res='h', min_area=100)
 ctx.add_basemap(ax=ax, crs=crs, attribution=False)
 
 
@@ -136,7 +138,7 @@ xu_grid_uds = dfmt.meshkernel_to_UgridDataset(mk, remove_noncontiguous=True, is_
 #TODO: get is_geographic from mk and drop as input argument: https:/https://github.com/Deltares/MeshKernelPy/issues/69/github.com/Deltares/MeshKernelPy/issues/69
 
 fig, ax = plt.subplots(figsize=figsize)
-xu_grid_uds.grid.plot(ax=ax) #TODO: maybe make uds instead of ds (but then bathy interpolation goes wrong)
+xu_grid_uds.grid.plot(ax=ax,linewidth=0.8) #TODO: maybe make uds instead of ds (but then bathy interpolation goes wrong)
 ctx.add_basemap(ax=ax, crs=crs, attribution=False)
 
 #interp bathy

--- a/tests/examples_workinprogress/workinprogress_meshkernel_creategrid.py
+++ b/tests/examples_workinprogress/workinprogress_meshkernel_creategrid.py
@@ -133,6 +133,7 @@ convert meshkernel grid to xugrid, interp bathymetry, plot and save to *_net.nc
 """
 
 xu_grid_uds = dfmt.meshkernel_to_UgridDataset(mk, remove_noncontiguous=True, is_geographic=is_geographic, crs=crs) #TODO: put remove_noncontiguous in meshkernel?: https://github.com/Deltares/MeshKernelPy/issues/44
+#TODO: get is_geographic from mk and drop as input argument: https:/https://github.com/Deltares/MeshKernelPy/issues/69/github.com/Deltares/MeshKernelPy/issues/69
 
 fig, ax = plt.subplots(figsize=figsize)
 xu_grid_uds.grid.plot(ax=ax) #TODO: maybe make uds instead of ds (but then bathy interpolation goes wrong)

--- a/tests/examples_workinprogress/workinprogress_modelbuilder.py
+++ b/tests/examples_workinprogress/workinprogress_modelbuilder.py
@@ -82,22 +82,7 @@ dfmt.meshkernel_delete_withcoastlines(mk=mk_object, res='h') #TODO: write used c
 # mk_object.mesh2d_delete_hanging_edges()
 
 #convert to xugrid
-xu_grid_uds = dfmt.meshkernel_to_UgridDataset(mk=mk_object)
-
-#TODO: temporary fix until code from issue-fix is in main branch: https://github.com/Deltares/dfm_tools/issues/421
-from netCDF4 import default_fillvals
-import numpy as np
-attribute_dict = {
-            'name': 'WGS84',
-            'epsg': np.array(4326, dtype=int),
-            'grid_mapping_name': 'latitude_longitude',
-            'longitude_of_prime_meridian': np.array(0.0, dtype=float),
-            'semi_major_axis': np.array(6378137.0, dtype=float),
-            'semi_minor_axis': np.array(6356752.314245, dtype=float),
-            'inverse_flattening': np.array(298.257223563, dtype=float),
-            'EPSG_code': 'EPSG:4326',
-            }
-xu_grid_uds['wgs84'] = xr.DataArray(np.array(default_fillvals['i4'],dtype=int),dims=(),attrs=attribute_dict)
+xu_grid_uds = dfmt.meshkernel_to_UgridDataset(mk=mk_object, is_geographic=is_geographic)
 
 #interp bathy
 data_bathy_interp = data_bathy_sel.interp(lon=xu_grid_uds.obj.mesh2d_node_x, lat=xu_grid_uds.obj.mesh2d_node_y).reset_coords(['lat','lon']) #interpolates lon/lat gebcodata to mesh2d_nNodes dimension #TODO: if these come from xu_grid_uds (without ojb), the mesh2d_node_z var has no ugrid accessor since the dims are lat/lon instead of mesh2d_nNodes
@@ -117,7 +102,7 @@ dfmt.plot_coastlines(ax=ax, crs=crs)
 netfile  = os.path.join(dir_output, f'{model_name}_net.nc')
 xu_grid_uds.ugrid.to_netcdf(netfile)
 
-
+breakit
 #%% generate plifile from grid extent 
 grid_bounds = xu_grid_uds.grid.bounds #TODO: maybe redefine lon_min etc instead. Also possible to get bounds from mk_object?
 pli_polyfile = dfmt.generate_bndpli(lon_min=grid_bounds[0], lon_max=grid_bounds[2], lat_min=grid_bounds[1], lat_max=grid_bounds[3], dlon=dxy, dlat=dxy, name=f'{model_name}_bnd')

--- a/tests/examples_workinprogress/workinprogress_modelbuilder.py
+++ b/tests/examples_workinprogress/workinprogress_modelbuilder.py
@@ -82,7 +82,7 @@ dfmt.meshkernel_delete_withcoastlines(mk=mk_object, res='h') #TODO: write used c
 # mk_object.mesh2d_delete_hanging_edges()
 
 #convert to xugrid
-xu_grid_uds = dfmt.meshkernel_to_UgridDataset(mk=mk_object, is_geographic=is_geographic)
+xu_grid_uds = dfmt.meshkernel_to_UgridDataset(mk=mk_object, is_geographic=is_geographic, crs=crs)
 
 #interp bathy
 data_bathy_interp = data_bathy_sel.interp(lon=xu_grid_uds.obj.mesh2d_node_x, lat=xu_grid_uds.obj.mesh2d_node_y).reset_coords(['lat','lon']) #interpolates lon/lat gebcodata to mesh2d_nNodes dimension #TODO: if these come from xu_grid_uds (without ojb), the mesh2d_node_z var has no ugrid accessor since the dims are lat/lon instead of mesh2d_nNodes

--- a/tests/examples_workinprogress/workinprogress_modelbuilder.py
+++ b/tests/examples_workinprogress/workinprogress_modelbuilder.py
@@ -82,7 +82,7 @@ dfmt.meshkernel_delete_withcoastlines(mk=mk_object, res='h') #TODO: write used c
 # mk_object.mesh2d_delete_hanging_edges()
 
 #convert to xugrid
-xu_grid_uds = dfmt.meshkernel_to_UgridDataset(mk=mk_object, is_geographic=is_geographic, crs=crs)
+xu_grid_uds = dfmt.meshkernel_to_UgridDataset(mk=mk_object, crs=crs)
 
 #interp bathy
 data_bathy_interp = data_bathy_sel.interp(lon=xu_grid_uds.obj.mesh2d_node_x, lat=xu_grid_uds.obj.mesh2d_node_y).reset_coords(['lat','lon']) #interpolates lon/lat gebcodata to mesh2d_nNodes dimension #TODO: if these come from xu_grid_uds (without ojb), the mesh2d_node_z var has no ugrid accessor since the dims are lat/lon instead of mesh2d_nNodes

--- a/tests/examples_workinprogress/workinprogress_modelbuilder.py
+++ b/tests/examples_workinprogress/workinprogress_modelbuilder.py
@@ -102,7 +102,7 @@ dfmt.plot_coastlines(ax=ax, crs=crs)
 netfile  = os.path.join(dir_output, f'{model_name}_net.nc')
 xu_grid_uds.ugrid.to_netcdf(netfile)
 
-breakit
+
 #%% generate plifile from grid extent 
 grid_bounds = xu_grid_uds.grid.bounds #TODO: maybe redefine lon_min etc instead. Also possible to get bounds from mk_object?
 pli_polyfile = dfmt.generate_bndpli(lon_min=grid_bounds[0], lon_max=grid_bounds[2], lat_min=grid_bounds[1], lat_max=grid_bounds[3], dlon=dxy, dlat=dxy, name=f'{model_name}_bnd')

--- a/tests/test_meshkernel_helpers.py
+++ b/tests/test_meshkernel_helpers.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Jul  5 12:59:23 2023
+
+@author: veenstra
+"""
+
+import pytest
+import xugrid as xu
+from dfm_tools.meshkernel_helpers import add_crs_to_dataset
+
+
+@pytest.mark.unittest
+def test_add_crs_to_dataset():
+    uds = xu.data.adh_san_diego()
+    crs='EPSG:26946' #TODO: this is not the correct crs for this model (plotting fails)
+    add_crs_to_dataset(uds,crs=crs,is_geographic=False)
+    crs_attrs = uds.projected_coordinate_system.attrs
+    
+    # import contextily as ctx
+    # import matplotlib.pyplot as plt
+    # plt.close('all')
+    # fig,ax = plt.subplots()
+    # uds.elevation.ugrid.plot(ax=ax)
+    # ctx.add_basemap(ax=ax,crs=crs)
+    
+    assert 'projected_coordinate_system' in uds.data_vars
+    assert crs_attrs['EPSG_code'] == 'EPSG:26946'
+    assert crs_attrs['epsg'] == 26946
+    assert crs_attrs['grid_mapping_name'] == 'Unknown projected'

--- a/tests/test_meshkernel_helpers.py
+++ b/tests/test_meshkernel_helpers.py
@@ -11,11 +11,10 @@ from dfm_tools.meshkernel_helpers import add_crs_to_dataset
 
 
 @pytest.mark.unittest
-def test_add_crs_to_dataset():
+def test_add_crs_to_dataset_cartesian():
     uds = xu.data.adh_san_diego()
     crs='EPSG:26946' #TODO: this is not the correct crs for this model (plotting fails)
     add_crs_to_dataset(uds,crs=crs,is_geographic=False)
-    crs_attrs = uds.projected_coordinate_system.attrs
     
     # import contextily as ctx
     # import matplotlib.pyplot as plt
@@ -25,6 +24,25 @@ def test_add_crs_to_dataset():
     # ctx.add_basemap(ax=ax,crs=crs)
     
     assert 'projected_coordinate_system' in uds.data_vars
+    crs_attrs = uds.projected_coordinate_system.attrs
     assert crs_attrs['EPSG_code'] == 'EPSG:26946'
     assert crs_attrs['epsg'] == 26946
     assert crs_attrs['grid_mapping_name'] == 'Unknown projected'
+
+def test_add_crs_to_dataset_spherical():
+    uds = xu.data.adh_san_diego()
+    crs='EPSG:4326' #TODO: this is not the correct crs for this model (plotting fails)
+    add_crs_to_dataset(uds,crs=crs,is_geographic=True)
+    
+    # import contextily as ctx
+    # import matplotlib.pyplot as plt
+    # plt.close('all')
+    # fig,ax = plt.subplots()
+    # uds.elevation.ugrid.plot(ax=ax)
+    # ctx.add_basemap(ax=ax,crs=crs)
+    
+    assert 'wgs84' in uds.data_vars
+    crs_attrs = uds.wgs84.attrs
+    assert crs_attrs['EPSG_code'] == 'EPSG:4326'
+    assert crs_attrs['epsg'] == 4326
+    assert crs_attrs['grid_mapping_name'] == 'latitude_longitude'

--- a/tests/test_meshkernel_helpers.py
+++ b/tests/test_meshkernel_helpers.py
@@ -13,15 +13,8 @@ from dfm_tools.meshkernel_helpers import add_crs_to_dataset
 @pytest.mark.unittest
 def test_add_crs_to_dataset_cartesian():
     uds = xu.data.adh_san_diego()
-    crs='EPSG:26946' #TODO: this is not the correct crs for this model (plotting fails)
+    crs='EPSG:26946' # this is not the correct crs for this model, but that does not matter
     add_crs_to_dataset(uds,crs=crs,is_geographic=False)
-    
-    # import contextily as ctx
-    # import matplotlib.pyplot as plt
-    # plt.close('all')
-    # fig,ax = plt.subplots()
-    # uds.elevation.ugrid.plot(ax=ax)
-    # ctx.add_basemap(ax=ax,crs=crs)
     
     assert 'projected_coordinate_system' in uds.data_vars
     crs_attrs = uds.projected_coordinate_system.attrs
@@ -31,15 +24,8 @@ def test_add_crs_to_dataset_cartesian():
 
 def test_add_crs_to_dataset_spherical():
     uds = xu.data.adh_san_diego()
-    crs='EPSG:4326' #TODO: this is not the correct crs for this model (plotting fails)
+    crs='EPSG:4326' # this is not the correct crs for this model, but that does not matter
     add_crs_to_dataset(uds,crs=crs,is_geographic=True)
-    
-    # import contextily as ctx
-    # import matplotlib.pyplot as plt
-    # plt.close('all')
-    # fig,ax = plt.subplots()
-    # uds.elevation.ugrid.plot(ax=ax)
-    # ctx.add_basemap(ax=ax,crs=crs)
     
     assert 'wgs84' in uds.data_vars
     crs_attrs = uds.wgs84.attrs

--- a/tests/test_meshkernel_helpers.py
+++ b/tests/test_meshkernel_helpers.py
@@ -7,14 +7,14 @@ Created on Wed Jul  5 12:59:23 2023
 
 import pytest
 import xugrid as xu
-from dfm_tools.meshkernel_helpers import add_crs_to_dataset
+from dfm_tools.meshkernel_helpers import add_crs_to_dataset, make_basegrid, meshkernel_check_geographic
 
 
 @pytest.mark.unittest
 def test_add_crs_to_dataset_cartesian():
     uds = xu.data.adh_san_diego()
     crs='EPSG:26946' # this is not the correct crs for this model, but that does not matter
-    add_crs_to_dataset(uds,crs=crs,is_geographic=False)
+    add_crs_to_dataset(uds,is_geographic=False,crs=crs)
     
     assert 'projected_coordinate_system' in uds.data_vars
     crs_attrs = uds.projected_coordinate_system.attrs
@@ -22,13 +22,33 @@ def test_add_crs_to_dataset_cartesian():
     assert crs_attrs['epsg'] == 26946
     assert crs_attrs['grid_mapping_name'] == 'Unknown projected'
 
+
+@pytest.mark.unittest
 def test_add_crs_to_dataset_spherical():
     uds = xu.data.adh_san_diego()
     crs='EPSG:4326' # this is not the correct crs for this model, but that does not matter
-    add_crs_to_dataset(uds,crs=crs,is_geographic=True)
+    add_crs_to_dataset(uds,is_geographic=True,crs=crs)
     
     assert 'wgs84' in uds.data_vars
     crs_attrs = uds.wgs84.attrs
     assert crs_attrs['EPSG_code'] == 'EPSG:4326'
     assert crs_attrs['epsg'] == 4326
     assert crs_attrs['grid_mapping_name'] == 'latitude_longitude'
+    
+
+@pytest.mark.systemtest
+def test_meshkernel_check_geographic():
+    """
+    to check whether is_geographic can be correctly derived from the mk object, for cartesian as well spherical objects
+    """
+    lon_min, lon_max, lat_min, lat_max = -68.55, -67.9, 11.8, 12.6
+    dxy = 0.05
+    
+    mk_cartesian = make_basegrid(lon_min, lon_max, lat_min, lat_max, dx=dxy, dy=dxy, is_geographic=False)
+    mk_cartesian_geograph = meshkernel_check_geographic(mk_cartesian)
+    mk_spherical = make_basegrid(lon_min, lon_max, lat_min, lat_max, dx=dxy, dy=dxy, is_geographic=True)
+    mk_spherical_geograph = meshkernel_check_geographic(mk_spherical)
+    
+    assert mk_cartesian_geograph==False
+    assert mk_spherical_geograph==True
+


### PR DESCRIPTION
The variable `wgs84` or `projected_coordinate_system` is created to enable dflowfm to distinguish between spherical/cartesian. For interacter, a network seems to be interpreted as cartesian, unless there is this empty wgs84 variable present with at least some of the prescribed attrs. However, in order to let the DeltaShell GUI read the coordinate system properly, probably more is needed. I have also seen a warning message from the kernel for a spherical model:
`"** WARNING: Missing coordinate reference system. Now using default: wgs84 (EPSG:4326)."`
For cartesian models, there might be even more information like a `wkt` attribute needed.

Could you provide feedback on what the GUI/kernel (minimally) expects/needs in order to properly read a network file and also where to get this information?

I see the wkt information can come from [gdal](https://gis.stackexchange.com/questions/60371/getting-coordinate-system-name-from-spatialreference-using-gdal-python), but since this is not pip installable I would like to avoid that dependency.

**EDIT**:
All now works (interacter and QGIS), one additional update is needed to wrap up this PR:
- check whether kernel also knows enough with this minimal epsg writing, there is a warning about a proj string not being read properly.