### PR TITLE
simplified remove_unassociated_edges with valid-edge-boolean from xugrid

### DIFF
--- a/dfm_tools/xugrid_helpers.py
+++ b/dfm_tools/xugrid_helpers.py
@@ -106,8 +106,13 @@ def remove_unassociated_edges(ds: xr.Dataset) -> xr.Dataset:
         DESCRIPTION.
 
     """
-    
+    return ds
     uds = xu.core.wrap.UgridDataset(ds)
+    
+    # escape for 1D networks
+    if isinstance(uds.grid,xu.Ugrid1d):
+        return ds
+    
     associated = uds.grid.validate_edge_node_connectivity()
     edge_dimension = uds.grid.edge_dimension
     

--- a/dfm_tools/xugrid_helpers.py
+++ b/dfm_tools/xugrid_helpers.py
@@ -107,8 +107,7 @@ def remove_unassociated_edges(ds: xr.Dataset, topology: str = None) -> xr.Datase
 
     """
     
-    test_grid = xu.Ugrid2d
-    if hasattr(test_grid,'validate_edge_node_connectivity'): #available in xugrid>0.6.2
+    if hasattr(xu.Ugrid2d,'validate_edge_node_connectivity'): #available in xugrid>0.6.2
         uds = xu.core.wrap.UgridDataset(ds)
         associated = uds.grid.validate_edge_node_connectivity()
         edge_dimension = uds.grid.edge_dimension

--- a/dfm_tools/xugrid_helpers.py
+++ b/dfm_tools/xugrid_helpers.py
@@ -107,8 +107,9 @@ def remove_unassociated_edges(ds: xr.Dataset, topology: str = None) -> xr.Datase
 
     """
     
-    uds = xu.core.wrap.UgridDataset(ds)
-    if hasattr(uds.grid,'validate_edge_node_connectivity'): #available in xugrid>0.6.2
+    test_grid = xu.Ugrid2d
+    if hasattr(test_grid,'validate_edge_node_connectivity'): #available in xugrid>0.6.2
+        uds = xu.core.wrap.UgridDataset(ds)
         associated = uds.grid.validate_edge_node_connectivity()
         edge_dimension = uds.grid.edge_dimension
     else: #workaround for xugrid<=0.6.2 #TODO: remove this when new xugrid release is available

--- a/dfm_tools/xugrid_helpers.py
+++ b/dfm_tools/xugrid_helpers.py
@@ -107,29 +107,9 @@ def remove_unassociated_edges(ds: xr.Dataset, topology: str = None) -> xr.Datase
 
     """
     
-    if hasattr(xu.Ugrid2d,'validate_edge_node_connectivity'): #available in xugrid>0.6.2
-        uds = xu.core.wrap.UgridDataset(ds)
-        associated = uds.grid.validate_edge_node_connectivity()
-        edge_dimension = uds.grid.edge_dimension
-    else: #workaround for xugrid<=0.6.2 #TODO: remove this when new xugrid release is available
-        if topology is None:
-            topology = xu.ugrid.ugridbase.AbstractUgrid._single_topology(ds)
-        
-        # collect names
-        connectivity = ds.ugrid_roles.connectivity[topology]
-        dimensions = ds.ugrid_roles.dimensions[topology]
-        
-        # return original dataset in case of 1D topology, it contains no fnc
-        if 'face_node_connectivity' not in connectivity:
-            print('[1D topology] ',end='')
-            return ds
-        
-        enc = ds[connectivity['edge_node_connectivity']].to_numpy()
-        fnc = ds[connectivity['face_node_connectivity']].to_numpy()
-        
-        associated = np.isin(enc, fnc)
-        associated = associated[:, 0] & associated[:, 1]
-        edge_dimension = dimensions['edge_dimension']
+    uds = xu.core.wrap.UgridDataset(ds)
+    associated = uds.grid.validate_edge_node_connectivity()
+    edge_dimension = uds.grid.edge_dimension
     
     if not associated.all():
          print(f"[{(~associated).sum()} unassociated edges removed] ",end='')

--- a/dfm_tools/xugrid_helpers.py
+++ b/dfm_tools/xugrid_helpers.py
@@ -106,7 +106,7 @@ def remove_unassociated_edges(ds: xr.Dataset) -> xr.Dataset:
         DESCRIPTION.
 
     """
-    return ds
+    
     uds = xu.core.wrap.UgridDataset(ds)
     
     # escape for 1D networks

--- a/dfm_tools/xugrid_helpers.py
+++ b/dfm_tools/xugrid_helpers.py
@@ -107,26 +107,33 @@ def remove_unassociated_edges(ds: xr.Dataset, topology: str = None) -> xr.Datase
 
     """
     
-    if topology is None:
-        topology = xu.ugrid.ugridbase.AbstractUgrid._single_topology(ds)
+    uds = xu.core.wrap.UgridDataset(ds)
+    if hasattr(uds.grid,'validate_edge_node_connectivity'): #available in xugrid>0.6.2
+        associated = uds.grid.validate_edge_node_connectivity()
+        edge_dimension = uds.grid.edge_dimension
+    else: #workaround for xugrid<=0.6.2 #TODO: remove this when new xugrid release is available
+        if topology is None:
+            topology = xu.ugrid.ugridbase.AbstractUgrid._single_topology(ds)
+        
+        # collect names
+        connectivity = ds.ugrid_roles.connectivity[topology]
+        dimensions = ds.ugrid_roles.dimensions[topology]
+        
+        # return original dataset in case of 1D topology, it contains no fnc
+        if 'face_node_connectivity' not in connectivity:
+            print('[1D topology] ',end='')
+            return ds
+        
+        enc = ds[connectivity['edge_node_connectivity']].to_numpy()
+        fnc = ds[connectivity['face_node_connectivity']].to_numpy()
+        
+        associated = np.isin(enc, fnc)
+        associated = associated[:, 0] & associated[:, 1]
+        edge_dimension = dimensions['edge_dimension']
     
-    # collect names
-    connectivity = ds.ugrid_roles.connectivity[topology]
-    dimensions = ds.ugrid_roles.dimensions[topology]
-    
-    # return original dataset in case of 1D topology, it contains no fnc
-    if 'face_node_connectivity' not in connectivity:
-        print('[1D topology] ',end='')
-        return ds
-    
-    enc = ds[connectivity['edge_node_connectivity']].to_numpy()
-    fnc = ds[connectivity['face_node_connectivity']].to_numpy()
-    
-    associated = np.isin(enc, fnc)
-    associated = associated[:, 0] & associated[:, 1]
     if not associated.all():
-        print(f"[{(~associated).sum()} unassociated edges removed] ",end='')
-        ds = ds.sel({dimensions['edge_dimension']: associated})
+         print(f"[{(~associated).sum()} unassociated edges removed] ",end='')
+         ds = ds.sel({edge_dimension: associated})
     return ds
 
 

--- a/dfm_tools/xugrid_helpers.py
+++ b/dfm_tools/xugrid_helpers.py
@@ -89,7 +89,7 @@ def remove_periodic_cells(uds): #TODO: implement proper fix: https://github.com/
     return uds
 
 
-def remove_unassociated_edges(ds: xr.Dataset, topology: str = None) -> xr.Dataset:
+def remove_unassociated_edges(ds: xr.Dataset) -> xr.Dataset:
     """
     Removes edges that are not associated to any of the faces, usecase in https://github.com/Deltares/xugrid/issues/68
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -5,7 +5,7 @@
 - interpolation of edge variables to faces with `dfmt.uda_edges_to_faces()` by [@veenstrajelmer](https://github.com/veenstrajelmer) in [#482](https://github.com/Deltares/dfm_tools/pull/482)
 - interpolation of variables on layer interfaces to layer centers with `dfmt.uda_interfaces_to_centers()` by [@veenstrajelmer](https://github.com/veenstrajelmer) in [#482](https://github.com/Deltares/dfm_tools/pull/482)
 - generate polyline only for open boundary with `dfmt.generate_bndpli_cutland()` (deprecates `dfmt.generate_bndpli()`) by [@veenstrajelmer](https://github.com/veenstrajelmer) in [#466](https://github.com/Deltares/dfm_tools/pull/466)
-- automatically remove unassociated edges with `dfmt.remove_unassociated_edges()` by [@veenstrajelmer](https://github.com/veenstrajelmer) in [#470](https://github.com/Deltares/dfm_tools/pull/470)
+- automatically remove unassociated edges with `dfmt.remove_unassociated_edges()` by [@veenstrajelmer](https://github.com/veenstrajelmer) in [#470](https://github.com/Deltares/dfm_tools/pull/470) and [#494](https://github.com/Deltares/dfm_tools/pull/494)
 
 ### Fix
 - removed `matplotlib._api` import to also support `matplotlib<3.4.0` by [@veenstrajelmer](https://github.com/veenstrajelmer) in [#465](https://github.com/Deltares/dfm_tools/pull/465)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ xarray
 dask
 netcdf4>=1.5.3
 bottleneck
-xugrid>=0.6.1
+xugrid>=0.6.4
 cdsapi
 pydap>=3.3.0
 hydrolib-core>=0.5.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
 	dask
 	netcdf4>=1.5.3
 	bottleneck
-	xugrid>=0.6.1
+	xugrid>=0.6.4
 	cdsapi
 	pydap>=3.3.0
 	hydrolib-core>=0.5.1


### PR DESCRIPTION
TODO:
- [x] wait for xugrid release that contains `uds.grid.validate_edge_node_connectivity()` (after 31 juli 2023) >> xugrid 0.6.4
- [x] update minimal xugrid requirement in setup.cfg and requirements.txt
- [x] remove old code in `dfmt.remove_unassociated_edges()`
- [x] make optional with default `True` like ghostcells
- [x] check/ask impact on performance in case of correct grid, unknown
- [x] add to line in whatsnew.md (including other PR)
- [x] fix failing local testcase by avoiding in case of ugrid1d