### PR TITLE
couple ecmwf parameter database

### DIFF
--- a/dfm_tools/download.py
+++ b/dfm_tools/download.py
@@ -93,6 +93,7 @@ def download_ERA5(varkey:str,
     Download ERA5 data via the CDS API by supplying the shortname
     An overview of parameters is available at https://codes.ecmwf.int/grib/param-db/
     However, this is does not always contain cfnames or they are incorrect, so a variables_dict is necessary for now.
+    Correct variables can be retrieved manually from https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-single-levels?tab=form
     
     Authentication with the CDS API is required: https://cds.climate.copernicus.eu/api-how-to
     The CDS apikey file "$HOME/.cdsapirc" is automatically created if you provide this key when requested
@@ -154,7 +155,7 @@ def download_ERA5(varkey:str,
                       'mer':'mean_evaporation_rate',
                       'mtpr':'mean_total_precipitation_rate',
                       'rhoao':'air_density_over_the_oceans', # returns dataset with varname p140209
-                      }    
+                      }
     
     if varkey in variables_dict.keys():
         param_cfname = variables_dict[varkey]

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 ### Feat
+- aquire cfname from ECMWF parameter database with `dfmt.get_ecmwf_cfname_from_shortname()` by [@veenstrajelmer](https://github.com/veenstrajelmer) in [#499](https://github.com/Deltares/dfm_tools/pull/499)
 - decoding of default fillvalues with `dfmt.decode_default_fillvals()` by [@veenstrajelmer](https://github.com/veenstrajelmer) in [#496](https://github.com/Deltares/dfm_tools/pull/496)
 - interpolation of edge variables to faces with `dfmt.uda_edges_to_faces()` by [@veenstrajelmer](https://github.com/veenstrajelmer) in [#482](https://github.com/Deltares/dfm_tools/pull/482)
 - interpolation of variables on layer interfaces to layer centers with `dfmt.uda_interfaces_to_centers()` by [@veenstrajelmer](https://github.com/veenstrajelmer) in [#482](https://github.com/Deltares/dfm_tools/pull/482)

--- a/tests/examples/download_meteodata_oceandata.py
+++ b/tests/examples/download_meteodata_oceandata.py
@@ -31,7 +31,7 @@ date_min = '2010-01-01'
 date_max = '2010-01-02'
 
 #variables per model will be written to separate netcdf files. Set to [] to skip model.
-variables_era5 = ['msl']#,'rhoao']#'v10n'] # check variables_dict in dfmt.download_ERA5() for valid names
+variables_era5 = ['rhoao']#'v10n'] # check variables_dict in dfmt.download_ERA5() for valid names
 varlist_cmems = []#'bottomT','thetao','no3'] # avaliable variables differ per product, examples are ['bottomT','mlotst','siconc','sithick','so','thetao','uo','vo','usi','vsi','zos','no3']. More info on https://data.marine.copernicus.eu/products
 varlist_hycom = []#'surf_el']#'water_temp'] #['tau','water_u','water_v','water_temp','salinity','surf_el']
 

--- a/tests/examples/download_meteodata_oceandata.py
+++ b/tests/examples/download_meteodata_oceandata.py
@@ -31,8 +31,8 @@ date_min = '2010-01-01'
 date_max = '2010-01-02'
 
 #variables per model will be written to separate netcdf files. Set to [] to skip model.
-variables_era5 = ['msl']#'v10n'] # check variables_dict in dfmt.download_ERA5() for valid names
-varlist_cmems = ['bottomT','thetao','no3'] # avaliable variables differ per product, examples are ['bottomT','mlotst','siconc','sithick','so','thetao','uo','vo','usi','vsi','zos','no3']. More info on https://data.marine.copernicus.eu/products
+variables_era5 = ['msl']#,'rhoao']#'v10n'] # check variables_dict in dfmt.download_ERA5() for valid names
+varlist_cmems = []#'bottomT','thetao','no3'] # avaliable variables differ per product, examples are ['bottomT','mlotst','siconc','sithick','so','thetao','uo','vo','usi','vsi','zos','no3']. More info on https://data.marine.copernicus.eu/products
 varlist_hycom = []#'surf_el']#'water_temp'] #['tau','water_u','water_v','water_temp','salinity','surf_el']
 
 #output directories per model

--- a/tests/examples/download_meteodata_oceandata.py
+++ b/tests/examples/download_meteodata_oceandata.py
@@ -31,8 +31,8 @@ date_min = '2010-01-01'
 date_max = '2010-01-02'
 
 #variables per model will be written to separate netcdf files. Set to [] to skip model.
-variables_era5 = ['msl']#['rhoao']#'v10n']
-varlist_cmems = []#'bottomT','thetao','no3'] # avaliable variables differ per product, examples are ['bottomT','mlotst','siconc','sithick','so','thetao','uo','vo','usi','vsi','zos','no3']. More info on https://data.marine.copernicus.eu/products
+variables_era5 = ['msl']#'v10n'] # check variables_dict in dfmt.download_ERA5() for valid names
+varlist_cmems = ['bottomT','thetao','no3'] # avaliable variables differ per product, examples are ['bottomT','mlotst','siconc','sithick','so','thetao','uo','vo','usi','vsi','zos','no3']. More info on https://data.marine.copernicus.eu/products
 varlist_hycom = []#'surf_el']#'water_temp'] #['tau','water_u','water_v','water_temp','salinity','surf_el']
 
 #output directories per model

--- a/tests/examples/download_meteodata_oceandata.py
+++ b/tests/examples/download_meteodata_oceandata.py
@@ -31,7 +31,7 @@ date_min = '2010-01-01'
 date_max = '2010-01-02'
 
 #variables per model will be written to separate netcdf files. Set to [] to skip model.
-variables_era5 = [('rhoao','air_density_over_the_ocean')]#'v10n'] # check variables_dict in dfmt.download_ERA5() for valid names
+variables_era5 = ['msl']#['rhoao']#'v10n']
 varlist_cmems = []#'bottomT','thetao','no3'] # avaliable variables differ per product, examples are ['bottomT','mlotst','siconc','sithick','so','thetao','uo','vo','usi','vsi','zos','no3']. More info on https://data.marine.copernicus.eu/products
 varlist_hycom = []#'surf_el']#'water_temp'] #['tau','water_u','water_v','water_temp','salinity','surf_el']
 

--- a/tests/examples/download_meteodata_oceandata.py
+++ b/tests/examples/download_meteodata_oceandata.py
@@ -31,7 +31,7 @@ date_min = '2010-01-01'
 date_max = '2010-01-02'
 
 #variables per model will be written to separate netcdf files. Set to [] to skip model.
-variables_era5 = ['rhoao']#'v10n'] # check variables_dict in dfmt.download_ERA5() for valid names
+variables_era5 = [('rhoao','air_density_over_the_ocean')]#'v10n'] # check variables_dict in dfmt.download_ERA5() for valid names
 varlist_cmems = []#'bottomT','thetao','no3'] # avaliable variables differ per product, examples are ['bottomT','mlotst','siconc','sithick','so','thetao','uo','vo','usi','vsi','zos','no3']. More info on https://data.marine.copernicus.eu/products
 varlist_hycom = []#'surf_el']#'water_temp'] #['tau','water_u','water_v','water_temp','salinity','surf_el']
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -28,3 +28,14 @@ def test_round_timestamp_to_outer_noon():
         assert date_max >= pd.Timestamp(date_max_mod)
         assert np.abs((date_min - pd.Timestamp(date_min_mod)).total_seconds()) < 24*3600
         assert np.abs((date_max - pd.Timestamp(date_max_mod)).total_seconds()) < 24*3600
+
+
+@pytest.mark.unittest
+def test_get_ecmwf_cfname_from_shortname():
+    # TODO: this test fails once the ECMWF parameter database is updated
+    # shortname msl will then return cfname mean_sea_level_pressure
+    # more issues mentioned in the description of https://github.com/Deltares/dfm_tools/pull/499
+    
+    param_cfname = dfmt.get_ecmwf_cfname_from_shortname('msl')
+    assert param_cfname == 'air_pressure_at_mean_sea_level'
+    


### PR DESCRIPTION
What does not work: The cfname is the standard_name and not the variable that is understood by the cdsapi request, so this we cannot use. The shortname returns arbitrary data or weird results. Also many netcdf parameters are not marked like such in the params-db.

Functions `get_ecmwf_paramdb_netcdf` and `get_ecmwf_paramid_from_shortname` are implemented. But we still need a hardcoded variables_dict since the params-db has missing/duplicate shortnames. Therefore, the functions do not provide any additional benefit if the param-db is not updated to contain this information. Support request pending: https://jira.ecmwf.int/plugins/servlet/desk/portal/1/CUS-23301

TODO:
- [ ] the [api-how-to page](https://cds.climate.copernicus.eu/api-how-to) mentions the requests should be constructed with the shortname. That would be very convenient, but unfortunately this does not work for most of the parameters. According to ECMWF helpdesk this is not right, it should be paramID or variablename
- [ ] correct variables can be manually retrieved via the [cds form](https://cds.climate.copernicus.eu/cdsapp#!/dataset/reanalysis-era5-single-levels?tab=form)
- [ ] paramID for many variables can be retrieved from [param-db JSON](https://codes.ecmwf.int/grib/param-db/json/), but many shortnames are duplicated and more issues in MWE comments below.

```
import cdsapi
import dfm_tools as dfmt

variables_dict = {'ssr':'surface_net_solar_radiation',
                  # 'sst':'sea_surface_temperature', # duplicate shortname, both not netcdf and wrong data
                  'strd':'surface_thermal_radiation_downwards',
                  'slhf':'surface_latent_heat_flux',
                  'sshf':'surface_sensible_heat_flux',
                  'str':'surface_net_thermal_radiation',
                  'chnk':'charnock',
                  # 'd2m':'2m_dewpoint_temperature', # d2m not in param-db, dp2m returns no data
                  # 't2m':'2m_temperature', # t2m not in param-db, tp2m returns no data
                  'tcc':'total_cloud_cover',
                  'msl':'mean_sea_level_pressure',
                  # 'u10':'10m_u_component_of_wind', # u10 not in param-db, u10m returns no data
                  'u10n':'10m_u_component_of_neutral_wind',
                  # 'v10':'10m_v_component_of_wind', # v10 not in param-db, v10m returns no data
                  'v10n':'10m_v_component_of_neutral_wind',
                  'mer':'mean_evaporation_rate', 
                  'mtpr':'mean_total_precipitation_rate',
                  'rhoao':'air_density_over_the_oceans', # AssertionError: varname returns dataset with varname p140209
                  }


for shortname in variables_dict.keys():
    paramid = dfmt.get_ecmwf_paramid_from_shortname(shortname)
    print(shortname, paramid)
    
    file_out = f'era5_{shortname}_test.nc'
    request_dict = {'product_type':'reanalysis',
                    'variable':str(paramid),
                    'year':2022,
                    'month':1,
                    'day':1,
                    'time':'00:00',
                    'area':'43.0/2.0/41.5/4.0', # north, west, south, east
                    'format':'netcdf'}
    
    c = cdsapi.Client()
    print(f'retrieving with shortname/paramid: {shortname}/{paramid}')
    c.retrieve(name='reanalysis-era5-single-levels', request=request_dict, target=file_out)
    
    import xarray as xr
    ds = xr.open_dataset(file_out)
    varn_inds = list(ds.data_vars)[0]
    assert varn_inds==shortname
    
    print(variables_dict[shortname])
    print(ds[shortname].attrs['long_name'])
    if 'standard_name' in ds[shortname].attrs:
        print(ds[shortname].attrs['standard_name'])
```
