### PR TITLE
add no_metadata_cache argument to copernicusmarine_credentials()

### DIFF
--- a/dfm_tools/download.py
+++ b/dfm_tools/download.py
@@ -320,7 +320,7 @@ def copernicusmarine_credentials():
     if not DEFAULT_CLIENT_CREDENTIALS_FILEPATH.is_file():
         print("Downloading CMEMS data requires a Copernicus Marine username and password, sign up for free at: https://data.marine.copernicus.eu/register.")
         username, password = get_and_check_username_password(**login_kwargs)
-        success = copernicusmarine.login(username=None, password=None)
+        success = copernicusmarine.login(username, password)
         if not success:
             raise InvalidUsernameOrPassword("invalid credentials")
     else:
@@ -328,15 +328,17 @@ def copernicusmarine_credentials():
     return username, password
 
 
-def copernicusmarine_reset():
-    print("resetting Copernicus Marine Toolbox, you will have to login again.")
-    dir_copernicusmarine = os.path.expanduser("~/.copernicusmarine")
-    print(f"- removing {dir_copernicusmarine}")
-    shutil.rmtree(dir_copernicusmarine, ignore_errors=True)
-    print("- overwriting copernicusmarine metadata cache (takes some time)")
-    subprocess.run("copernicusmarine describe --overwrite-metadata-cache")
-    print("- updating copernicusmarine")
-    subprocess.run("pip install copernicusmarine -U")
+def copernicusmarine_reset(remove_folder=False, overwrite_cache=True, update_package=False):
+    if remove_folder:
+        dir_copernicusmarine = os.path.expanduser("~/.copernicusmarine")
+        print(f"reset copernicusmarine: removing {dir_copernicusmarine}, you will have to login again.")
+        shutil.rmtree(dir_copernicusmarine, ignore_errors=True)
+    if overwrite_cache:
+        print("reset copernicusmarine: overwriting copernicusmarine metadata cache (takes some time)")
+        subprocess.run("copernicusmarine describe --overwrite-metadata-cache")
+    if update_package:
+        print("reset copernicusmarine: updating copernicusmarine")
+        subprocess.run("pip install copernicusmarine -U")
 
 
 def copernicusmarine_dataset_timerange(dataset_id):

--- a/dfm_tools/download.py
+++ b/dfm_tools/download.py
@@ -316,14 +316,15 @@ def copernicusmarine_credentials():
         InvalidUsernameOrPassword,
         get_and_check_username_password,
     )
+    login_kwargs = dict(username=None, password=None, credentials_file=DEFAULT_CLIENT_CREDENTIALS_FILEPATH, no_metadata_cache=False)
     if not DEFAULT_CLIENT_CREDENTIALS_FILEPATH.is_file():
         print("Downloading CMEMS data requires a Copernicus Marine username and password, sign up for free at: https://data.marine.copernicus.eu/register.")
-        username, password = get_and_check_username_password(username=None, password=None, credentials_file=DEFAULT_CLIENT_CREDENTIALS_FILEPATH)
-        success = copernicusmarine.login(username, password)
+        username, password = get_and_check_username_password(**login_kwargs)
+        success = copernicusmarine.login(username=None, password=None)
         if not success:
             raise InvalidUsernameOrPassword("invalid credentials")
     else:
-        username, password = get_and_check_username_password(username=None, password=None, credentials_file=DEFAULT_CLIENT_CREDENTIALS_FILEPATH)
+        username, password = get_and_check_username_password(**login_kwargs)
     return username, password
 
 

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -1,5 +1,8 @@
 ## UNRELEASED
 
+### Fix
+- solve xarray FutureWarning about `ds.dims[dim]` by [@veenstrajelmer](https://github.com/veenstrajelmer) in [#779](https://github.com/Deltares/dfm_tools/pull/779)
+- add `no_metadata_cache` argument to `copernicusmarine_credentials()` to support copernicusmarine>=1.0.2 by [@veenstrajelmer](https://github.com/veenstrajelmer) in [#787](https://github.com/Deltares/dfm_tools/pull/787)
 
 
 ## 0.19.0 (2024-02-08)

--- a/docs/whats-new.md
+++ b/docs/whats-new.md
@@ -2,7 +2,7 @@
 
 ### Fix
 - solve xarray FutureWarning about `ds.dims[dim]` by [@veenstrajelmer](https://github.com/veenstrajelmer) in [#779](https://github.com/Deltares/dfm_tools/pull/779)
-- add `no_metadata_cache` argument to `copernicusmarine_credentials()` to support copernicusmarine>=1.0.2 by [@veenstrajelmer](https://github.com/veenstrajelmer) in [#787](https://github.com/Deltares/dfm_tools/pull/787)
+- support copernicusmarine>=1.0.2 in `copernicusmarine_credentials()` and made `copernicusmarine_reset()` modular by [@veenstrajelmer](https://github.com/veenstrajelmer) in [#787](https://github.com/Deltares/dfm_tools/pull/787)
 
 
 ## 0.19.0 (2024-02-08)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ dependencies = [
 	"pydap>=3.4.0",
 	#erddapy<2.0.0 does not support pandas>=2.0.0
 	"erddapy>=2.0.0",
-	#copernicusmarine<1.0.1 does not support python 3.12
-	"copernicusmarine>=1.0.1",
+	#copernicusmarine<1.0.2 does not support no_metadata_cache in get_and_check_username_password function
+	"copernicusmarine>=1.0.2",
 	#pooch<1.1.0 do not have attribute retrieve
 	"pooch>=1.1.0",
 	#hydrolib-core 0.6.0 supports meshkernel>=3.0.0


### PR DESCRIPTION
 to support copernicusmarine>=1.0.2